### PR TITLE
Reduce heroku slug size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# Compiled Angular frontend files
+dist/

--- a/.slugignore
+++ b/.slugignore
@@ -1,0 +1,3 @@
+*.go
+frontend/
+*.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
 - go test ./...
 - go build -o japare -v .
 - cd frontend
-- npm run-script build
+- npm run-script build-prod
 - cd ..
 deploy:
   skip_cleanup: true

--- a/deploy/heroku.sh
+++ b/deploy/heroku.sh
@@ -1,2 +1,0 @@
-heroku login
-heroku container:login

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve --open --port 4800",
-    "build": "ng build",
+    "build": "ng build --outputPath=../dist",
+    "build-prod": "ng build --prod --outputPath=../dist",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e"

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ func main() {
 
 	pathStatic, ok := os.LookupEnv("STATIC_FILES")
 	if !ok {
-		pathStatic = "frontend/dist/frontend/"
+		pathStatic = "dist/frontend/"
 	}
 
 	router := mux.NewRouter()
@@ -46,7 +46,7 @@ func main() {
 
 	log.Println("Serving at port ", port)
 	log.Printf("Trying to find static files at: '%v'\n", pathStatic)
-	log.Printf("Trying to find index html at: '%v'/index.html\n", pathStatic)
+	log.Printf("Trying to find index html at: '%vindex.html'\n", pathStatic)
 
 	log.Fatal(http.ListenAndServe("0.0.0.0:"+port, router))
 }


### PR DESCRIPTION
With a pretty barebones projects our Heroku slug size is already at 79mb.

This PR takes several actions to reduce the slug size

 - move dist folder to root
 - ignore .go files, ignore .md files
 - ignore entire frontend/ folder

Related issues : #29 